### PR TITLE
Handle empty PDF upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,19 +85,22 @@ def main():
         pdf_docs = st.file_uploader(
             "Upload your PDFs here and click on 'Process'", accept_multiple_files=True)
         if st.button("Process"):
-            with st.spinner("Processing"):
-                # get pdf text
-                raw_text = get_pdf_text(pdf_docs)
+            if pdf_docs:
+                with st.spinner("Processing"):
+                    # get pdf text
+                    raw_text = get_pdf_text(pdf_docs)
 
-                # get the text chunks
-                text_chunks = get_text_chunks(raw_text)
+                    # get the text chunks
+                    text_chunks = get_text_chunks(raw_text)
 
-                # create vector store
-                vectorstore = get_vectorstore(text_chunks)
+                    # create vector store
+                    vectorstore = get_vectorstore(text_chunks)
 
-                # create conversation chain
-                st.session_state.conversation = get_conversation_chain(
-                    vectorstore)
+                    # create conversation chain
+                    st.session_state.conversation = get_conversation_chain(
+                        vectorstore)
+            else:
+                st.warning("Please upload at least one PDF file.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a guard to only process PDFs when files were uploaded
- warn the user when no PDF files are provided

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466baea2a4832e8e9e1ea5ddb879cd