### PR TITLE
Update README with env example usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,16 +34,24 @@ To install the MultiPDF Chat App, please follow these steps:
    pip install -r requirements.txt
    ```
 
-3. Obtain an API key from OpenAI and add it to the `.env` file in the project directory.
-```commandline
-OPENAI_API_KEY=your_secrit_api_key
-```
+3. Copy the provided `.env.example` file to `.env`:
+   ```bash
+   cp .env.example .env
+   ```
+
+4. Edit `.env` and add your API keys. The application uses two environment variables:
+   - `OPENAI_API_KEY`: your OpenAI API key
+   - `HUGGINGFACEHUB_API_TOKEN`: your Hugging Face Hub token
+   ```env
+   OPENAI_API_KEY=your_openai_key
+   HUGGINGFACEHUB_API_TOKEN=your_huggingface_token
+   ```
 
 ## Usage
 -----
 To use the MultiPDF Chat App, follow these steps:
 
-1. Ensure that you have installed the required dependencies and added the OpenAI API key to the `.env` file.
+1. Ensure that you have installed the required dependencies and added your API keys to the `.env` file.
 
 2. Run the `main.py` file using the Streamlit CLI. Execute the following command:
    ```


### PR DESCRIPTION
## Summary
- add instructions for `.env.example`
- document OPENAI_API_KEY and HUGGINGFACEHUB_API_TOKEN usage
- mention copying `.env.example` to `.env`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466b35814c832e921d8ad7da92195c