### PR TITLE
Fix README run command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ To use the MultiPDF Chat App, follow these steps:
 
 1. Ensure that you have installed the required dependencies and added the OpenAI API key to the `.env` file.
 
-2. Run the `main.py` file using the Streamlit CLI. Execute the following command:
+2. Run the `app.py` file using the Streamlit CLI. Execute the following command:
    ```
    streamlit run app.py
    ```


### PR DESCRIPTION
## Summary
- update README to reference running `app.py`

## Testing
- `pytest -q` *(fails: pyenv missing Python 3.9)*

------
https://chatgpt.com/codex/tasks/task_e_68466bc1f9f0832e991894b9880b73be