### PR TITLE
Fix typo in API key snippet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ To install the MultiPDF Chat App, please follow these steps:
 
 3. Obtain an API key from OpenAI and add it to the `.env` file in the project directory.
 ```commandline
-OPENAI_API_KEY=your_secrit_api_key
+OPENAI_API_KEY=your_secret_api_key
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- update API key placeholder

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68466beb44b8832e9aa246299be72de4